### PR TITLE
feat: add enum support

### DIFF
--- a/psycopg/psycopg/_typeinfo.py
+++ b/psycopg/psycopg/_typeinfo.py
@@ -6,7 +6,7 @@ information to the adapters if needed.
 """
 
 # Copyright (C) 2020 The Psycopg Team
-
+from enum import Enum
 from typing import Any, Dict, Iterator, Optional, overload
 from typing import Sequence, Tuple, Type, TypeVar, Union, TYPE_CHECKING
 
@@ -282,6 +282,42 @@ LEFT JOIN (
     GROUP BY attrelid
 ) a ON a.attrelid = t.typrelid
 WHERE t.oid = %(name)s::regtype
+"""
+
+
+class EnumInfo(TypeInfo):
+    """Manage information about an enum type."""
+
+    __module__ = "psycopg.types.enum"
+
+    def __init__(
+        self,
+        name: str,
+        oid: int,
+        array_oid: int,
+        labels: Sequence[str],
+    ):
+        super().__init__(name, oid, array_oid)
+        self.labels = labels
+        # Will be set by register_enum()
+        self.enum: Optional[Type[Enum]] = None
+
+    @classmethod
+    def _get_info_query(
+        cls, conn: "Union[Connection[Any], AsyncConnection[Any]]"
+    ) -> str:
+        return """\
+SELECT
+    t.typname AS name, t.oid AS oid, t.typarray AS array_oid,
+    array_agg(x.enumlabel) AS labels
+FROM pg_type t
+LEFT JOIN (
+    SELECT e.enumtypid, e.enumlabel
+    FROM pg_enum e
+    ORDER BY e.enumsortorder
+) x ON x.enumtypid = t.oid
+WHERE t.oid = %(name)s::regtype
+GROUP BY t.typname, t.oid, t.typarray
 """
 
 

--- a/psycopg/psycopg/postgres.py
+++ b/psycopg/psycopg/postgres.py
@@ -107,13 +107,14 @@ TEXT_ARRAY_OID = types["text"].array_oid
 
 def register_default_adapters(context: AdaptContext) -> None:
 
-    from .types import array, bool, composite, datetime, json, multirange
+    from .types import array, bool, composite, datetime, enum, json, multirange
     from .types import net, none, numeric, range, string, uuid
 
     array.register_default_adapters(context)
     bool.register_default_adapters(context)
     composite.register_default_adapters(context)
     datetime.register_default_adapters(context)
+    enum.register_default_adapters(context)
     json.register_default_adapters(context)
     multirange.register_default_adapters(context)
     net.register_default_adapters(context)

--- a/psycopg/psycopg/types/enum.py
+++ b/psycopg/psycopg/types/enum.py
@@ -1,0 +1,177 @@
+"""
+Adapters for the enum type.
+"""
+from enum import Enum
+from typing import Any, Dict, Generic, Optional, Mapping, Sequence
+from typing import Tuple, Type, TypeVar, Union, cast
+
+from .. import postgres
+from .. import errors as e
+from ..pq import Format
+from ..abc import AdaptContext
+from ..adapt import Buffer, Dumper, Loader
+from .._compat import TypeAlias
+from .._encodings import conn_encoding
+from .._typeinfo import EnumInfo as EnumInfo  # exported here
+
+E = TypeVar("E", bound=Enum)
+
+EnumDumpMap: TypeAlias = Dict[E, bytes]
+EnumLoadMap: TypeAlias = Dict[bytes, E]
+EnumMapping: TypeAlias = Union[Mapping[E, str], Sequence[Tuple[E, str]], None]
+
+
+class _BaseEnumLoader(Loader, Generic[E]):
+    """
+    Dumper for a specific Enum class
+    """
+
+    enum: Type[E]
+    _load_map: EnumLoadMap[E]
+
+    def load(self, data: Buffer) -> E:
+        if not isinstance(data, bytes):
+            data = bytes(data)
+
+        try:
+            return self._load_map[data]
+        except KeyError:
+            enc = conn_encoding(self.connection)
+            label = data.decode(enc, "replace")  # type: ignore[union-attr]
+            raise e.DataError(
+                f"bad memeber for enum {self.enum.__qualname__}: {label!r}"
+            )
+
+
+class _BaseEnumDumper(Dumper, Generic[E]):
+    """
+    Loader for a specific Enum class
+    """
+
+    enum: Type[E]
+    _dump_map: EnumDumpMap[E]
+
+    def dump(self, value: E) -> Buffer:
+        return self._dump_map[value]
+
+
+class EnumDumper(Dumper):
+    """
+    Dumper for a generic Enum class
+    """
+
+    def __init__(self, cls: type, context: Optional[AdaptContext] = None):
+        super().__init__(cls, context)
+        self._encoding = conn_encoding(self.connection)
+
+    def dump(self, value: E) -> Buffer:
+        return value.name.encode(self._encoding)
+
+
+class EnumBinaryDumper(EnumDumper):
+    format = Format.BINARY
+
+
+def register_enum(
+    info: EnumInfo,
+    context: Optional[AdaptContext] = None,
+    enum: Optional[Type[E]] = None,
+    *,
+    mapping: EnumMapping[E] = None,
+) -> None:
+    """Register the adapters to load and dump a enum type.
+
+    :param info: The object with the information about the enum to register.
+    :param context: The context where to register the adapters. If `!None`,
+        register it globally.
+    :param enum: Python enum type matching to the PostgreSQL one. If `!None`,
+        a new enum will be generated and exposed as `EnumInfo.enum`.
+    :param mapping: Override the mapping between `!enum` members and `!info`
+        labels.
+    """
+
+    if not info:
+        raise TypeError("no info passed. Is the requested enum available?")
+
+    if enum is None:
+        enum = cast(Type[E], Enum(info.name.title(), info.labels, module=__name__))
+
+    info.enum = enum
+    adapters = context.adapters if context else postgres.adapters
+    info.register(context)
+
+    load_map = _make_load_map(info, enum, mapping, context)
+    attribs: Dict[str, Any] = {"enum": info.enum, "_load_map": load_map}
+
+    name = f"{info.name.title()}Loader"
+    loader = type(name, (_BaseEnumLoader,), attribs)
+    adapters.register_loader(info.oid, loader)
+
+    name = f"{info.name.title()}BinaryLoader"
+    loader = type(name, (_BaseEnumLoader,), {**attribs, "format": Format.BINARY})
+    adapters.register_loader(info.oid, loader)
+
+    dump_map = _make_dump_map(info, enum, mapping, context)
+    attribs = {"oid": info.oid, "enum": info.enum, "_dump_map": dump_map}
+
+    name = f"{enum.__name__}Dumper"
+    dumper = type(name, (_BaseEnumDumper,), attribs)
+    adapters.register_dumper(info.enum, dumper)
+
+    name = f"{enum.__name__}BinaryDumper"
+    dumper = type(name, (_BaseEnumDumper,), {**attribs, "format": Format.BINARY})
+    adapters.register_dumper(info.enum, dumper)
+
+
+def _make_load_map(
+    info: EnumInfo,
+    enum: Type[E],
+    mapping: EnumMapping[E],
+    context: Optional[AdaptContext],
+) -> EnumLoadMap[E]:
+    enc = conn_encoding(context.connection if context else None)
+    rv: EnumLoadMap[E] = {}
+    for label in info.labels:
+        try:
+            member = enum[label]
+        except KeyError:
+            # tolerate a missing enum, assuming it won't be used. If it is we
+            # will get a DataError on fetch.
+            pass
+        else:
+            rv[label.encode(enc)] = member
+
+    if mapping:
+        if isinstance(mapping, Mapping):
+            mapping = list(mapping.items())
+
+        for member, label in mapping:
+            rv[label.encode(enc)] = member
+
+    return rv
+
+
+def _make_dump_map(
+    info: EnumInfo,
+    enum: Type[E],
+    mapping: EnumMapping[E],
+    context: Optional[AdaptContext],
+) -> EnumDumpMap[E]:
+    enc = conn_encoding(context.connection if context else None)
+    rv: EnumDumpMap[E] = {}
+    for member in enum:
+        rv[member] = member.name.encode(enc)
+
+    if mapping:
+        if isinstance(mapping, Mapping):
+            mapping = list(mapping.items())
+
+        for member, label in mapping:
+            rv[member] = label.encode(enc)
+
+    return rv
+
+
+def register_default_adapters(context: AdaptContext) -> None:
+    context.adapters.register_dumper(Enum, EnumBinaryDumper)
+    context.adapters.register_dumper(Enum, EnumDumper)

--- a/tests/fix_faker.py
+++ b/tests/fix_faker.py
@@ -368,6 +368,13 @@ class Faker:
         else:
             assert got == want
 
+    def schema_Enum(self, cls):
+        # TODO: can't fake those as we would need to create temporary types
+        return None
+
+    def make_Enum(self, spec):
+        return None
+
     def make_float(self, spec, double=True):
         if random() <= 0.99:
             # These exponents should generate no inf

--- a/tests/types/test_enum.py
+++ b/tests/types/test_enum.py
@@ -1,0 +1,349 @@
+from enum import Enum, auto
+
+import pytest
+
+from psycopg import pq, sql, errors as e
+from psycopg.adapt import PyFormat
+from psycopg.types import TypeInfo
+from psycopg.types.enum import EnumInfo, register_enum
+
+
+class PureTestEnum(Enum):
+    FOO = auto()
+    BAR = auto()
+    BAZ = auto()
+
+
+class StrTestEnum(str, Enum):
+    ONE = "ONE"
+    TWO = "TWO"
+    THREE = "THREE"
+
+
+NonAsciiEnum = Enum(
+    "NonAsciiEnum",
+    {"X\xe0": "x\xe0", "X\xe1": "x\xe1", "COMMA": "foo,bar"},
+    type=str,
+)
+
+
+class IntTestEnum(int, Enum):
+    ONE = 1
+    TWO = 2
+    THREE = 3
+
+
+enum_cases = [PureTestEnum, StrTestEnum, IntTestEnum]
+encodings = ["utf8", "latin1"]
+
+
+@pytest.fixture(scope="session", autouse=True)
+def make_test_enums(request, svcconn):
+    for enum in enum_cases + [NonAsciiEnum]:
+        ensure_enum(enum, svcconn)
+
+
+def ensure_enum(enum, conn):
+    name = enum.__name__.lower()
+    labels = list(enum.__members__)
+    conn.execute(
+        sql.SQL(
+            """
+            drop type if exists {name} cascade;
+            create type {name} as enum ({labels});
+            """
+        ).format(name=sql.Identifier(name), labels=sql.SQL(",").join(labels))
+    )
+    return name, enum, labels
+
+
+def test_fetch_info(conn):
+    info = EnumInfo.fetch(conn, "StrTestEnum")
+    assert info.name == "strtestenum"
+    assert info.oid > 0
+    assert info.oid != info.array_oid > 0
+    assert len(info.labels) == len(StrTestEnum)
+    assert info.labels == list(StrTestEnum.__members__)
+
+
+@pytest.mark.asyncio
+async def test_fetch_info_async(aconn):
+    info = await EnumInfo.fetch(aconn, "PureTestEnum")
+    assert info.name == "puretestenum"
+    assert info.oid > 0
+    assert info.oid != info.array_oid > 0
+    assert len(info.labels) == len(PureTestEnum)
+    assert info.labels == list(PureTestEnum.__members__)
+
+
+def test_register_makes_a_type(conn):
+    info = EnumInfo.fetch(conn, "IntTestEnum")
+    assert info
+    assert info.enum is None
+    register_enum(info, context=conn)
+    assert info.enum is not None
+    assert [e.name for e in info.enum] == list(IntTestEnum.__members__)
+
+
+@pytest.mark.parametrize("enum", enum_cases)
+@pytest.mark.parametrize("fmt_in", PyFormat)
+@pytest.mark.parametrize("fmt_out", pq.Format)
+def test_enum_loader(conn, enum, fmt_in, fmt_out):
+    info = EnumInfo.fetch(conn, enum.__name__)
+    register_enum(info, conn, enum=enum)
+
+    for label in info.labels:
+        cur = conn.execute(
+            f"select %{fmt_in}::{enum.__name__}", [label], binary=fmt_out
+        )
+        assert cur.fetchone()[0] == enum[label]
+
+
+@pytest.mark.parametrize("encoding", encodings)
+@pytest.mark.parametrize("fmt_in", PyFormat)
+@pytest.mark.parametrize("fmt_out", pq.Format)
+def test_enum_loader_nonascii(conn, encoding, fmt_in, fmt_out):
+    enum = NonAsciiEnum
+    conn.execute(f"set client_encoding to {encoding}")
+
+    info = EnumInfo.fetch(conn, enum.__name__)
+    register_enum(info, conn, enum=enum)
+
+    for label in info.labels:
+        cur = conn.execute(f"select %{fmt_in}::{info.name}", [label], binary=fmt_out)
+        assert cur.fetchone()[0] == enum[label]
+
+
+@pytest.mark.parametrize("enum", enum_cases)
+@pytest.mark.parametrize("fmt_in", PyFormat)
+@pytest.mark.parametrize("fmt_out", pq.Format)
+def test_enum_loader_sqlascii(conn, enum, fmt_in, fmt_out):
+    info = EnumInfo.fetch(conn, enum.__name__)
+    register_enum(info, conn, enum)
+    conn.execute("set client_encoding to sql_ascii")
+
+    for label in info.labels:
+        cur = conn.execute(f"select %{fmt_in}::{info.name}", [label], binary=fmt_out)
+        assert cur.fetchone()[0] == enum[label]
+
+
+@pytest.mark.parametrize("enum", enum_cases)
+@pytest.mark.parametrize("fmt_in", PyFormat)
+@pytest.mark.parametrize("fmt_out", pq.Format)
+def test_enum_dumper(conn, enum, fmt_in, fmt_out):
+    info = EnumInfo.fetch(conn, enum.__name__)
+    register_enum(info, conn, enum)
+
+    for item in enum:
+        cur = conn.execute(f"select %{fmt_in}", [item], binary=fmt_out)
+        assert cur.fetchone()[0] == item
+
+
+@pytest.mark.parametrize("encoding", encodings)
+@pytest.mark.parametrize("fmt_in", PyFormat)
+@pytest.mark.parametrize("fmt_out", pq.Format)
+def test_enum_dumper_nonascii(conn, encoding, fmt_in, fmt_out):
+    enum = NonAsciiEnum
+    conn.execute(f"set client_encoding to {encoding}")
+
+    info = EnumInfo.fetch(conn, enum.__name__)
+    register_enum(info, conn, enum)
+
+    for item in enum:
+        cur = conn.execute(f"select %{fmt_in}", [item], binary=fmt_out)
+        assert cur.fetchone()[0] == item
+
+
+@pytest.mark.parametrize("enum", enum_cases)
+@pytest.mark.parametrize("fmt_in", PyFormat)
+@pytest.mark.parametrize("fmt_out", pq.Format)
+def test_enum_dumper_sqlascii(conn, enum, fmt_in, fmt_out):
+    info = EnumInfo.fetch(conn, enum.__name__)
+    register_enum(info, conn, enum)
+    conn.execute("set client_encoding to sql_ascii")
+
+    for item in enum:
+        cur = conn.execute(f"select %{fmt_in}", [item], binary=fmt_out)
+        assert cur.fetchone()[0] == item
+
+
+@pytest.mark.parametrize("enum", enum_cases)
+@pytest.mark.parametrize("fmt_in", PyFormat)
+@pytest.mark.parametrize("fmt_out", pq.Format)
+def test_generic_enum_dumper(conn, enum, fmt_in, fmt_out):
+    for item in enum:
+        if enum is PureTestEnum:
+            want = item.name
+        else:
+            want = item.value
+
+        cur = conn.execute(f"select %{fmt_in}", [item], binary=fmt_out)
+        assert cur.fetchone()[0] == want
+
+
+@pytest.mark.parametrize("encoding", encodings)
+@pytest.mark.parametrize("fmt_in", PyFormat)
+@pytest.mark.parametrize("fmt_out", pq.Format)
+def test_generic_enum_dumper_nonascii(conn, encoding, fmt_in, fmt_out):
+    conn.execute(f"set client_encoding to {encoding}")
+    for item in NonAsciiEnum:
+        cur = conn.execute(f"select %{fmt_in}", [item.value], binary=fmt_out)
+        assert cur.fetchone()[0] == item.value
+
+
+@pytest.mark.parametrize("enum", enum_cases)
+@pytest.mark.parametrize("fmt_in", PyFormat)
+@pytest.mark.parametrize("fmt_out", pq.Format)
+def test_generic_enum_loader(conn, enum, fmt_in, fmt_out):
+    for label in enum.__members__:
+        cur = conn.execute(
+            f"select %{fmt_in}::{enum.__name__}", [label], binary=fmt_out
+        )
+        want = enum[label].name
+        if fmt_out == pq.Format.BINARY:
+            want = want.encode()
+        assert cur.fetchone()[0] == want
+
+
+@pytest.mark.parametrize("encoding", encodings)
+@pytest.mark.parametrize("fmt_in", PyFormat)
+@pytest.mark.parametrize("fmt_out", pq.Format)
+def test_generic_enum_loader_nonascii(conn, encoding, fmt_in, fmt_out):
+    conn.execute(f"set client_encoding to {encoding}")
+
+    for label in NonAsciiEnum.__members__:
+        cur = conn.execute(f"select %{fmt_in}::nonasciienum", [label], binary=fmt_out)
+        if fmt_out == pq.Format.TEXT:
+            assert cur.fetchone()[0] == label
+        else:
+            assert cur.fetchone()[0] == label.encode(encoding)
+
+
+@pytest.mark.parametrize("fmt_in", PyFormat)
+@pytest.mark.parametrize("fmt_out", pq.Format)
+def test_enum_array_loader(conn, fmt_in, fmt_out):
+    enum = PureTestEnum
+    info = EnumInfo.fetch(conn, enum.__name__)
+    register_enum(info, conn, enum)
+
+    labels = list(enum.__members__)
+    cur = conn.execute(f"select %{fmt_in}::{info.name}[]", [labels], binary=fmt_out)
+    assert cur.fetchone()[0] == list(enum)
+
+
+@pytest.mark.parametrize("fmt_in", PyFormat)
+@pytest.mark.parametrize("fmt_out", pq.Format)
+def test_enum_array_dumper(conn, fmt_in, fmt_out):
+    enum = StrTestEnum
+    info = EnumInfo.fetch(conn, enum.__name__)
+    register_enum(info, conn, enum)
+
+    cur = conn.execute(f"select %{fmt_in}::text[]", [list(enum)], binary=fmt_out)
+    assert cur.fetchone()[0] == list(enum.__members__)
+
+
+@pytest.mark.parametrize("fmt_in", PyFormat)
+@pytest.mark.parametrize("fmt_out", pq.Format)
+def test_generic_enum_array_loader(conn, fmt_in, fmt_out):
+    enum = IntTestEnum
+    info = TypeInfo.fetch(conn, enum.__name__)
+    info.register(conn)
+    labels = list(enum.__members__)
+    cur = conn.execute(f"select %{fmt_in}::{info.name}[]", [labels], binary=fmt_out)
+    if fmt_out == pq.Format.TEXT:
+        assert cur.fetchone()[0] == labels
+    else:
+        assert cur.fetchone()[0] == [item.encode() for item in labels]
+
+
+def test_enum_error(conn):
+    conn.autocommit = True
+
+    info = EnumInfo.fetch(conn, "puretestenum")
+    register_enum(info, conn, StrTestEnum)
+
+    with pytest.raises(e.DataError):
+        conn.execute("select %s::text", [StrTestEnum.ONE]).fetchone()
+    with pytest.raises(e.DataError):
+        conn.execute("select 'BAR'::puretestenum").fetchone()
+
+
+@pytest.mark.parametrize("fmt_in", PyFormat)
+@pytest.mark.parametrize("fmt_out", pq.Format)
+@pytest.mark.parametrize(
+    "mapping",
+    [
+        {StrTestEnum.ONE: "FOO", StrTestEnum.TWO: "BAR", StrTestEnum.THREE: "BAZ"},
+        [
+            (StrTestEnum.ONE, "FOO"),
+            (StrTestEnum.TWO, "BAR"),
+            (StrTestEnum.THREE, "BAZ"),
+        ],
+    ],
+)
+def test_remap(conn, fmt_in, fmt_out, mapping):
+    info = EnumInfo.fetch(conn, "puretestenum")
+    register_enum(info, conn, StrTestEnum, mapping=mapping)
+
+    for member, label in [("ONE", "FOO"), ("TWO", "BAR"), ("THREE", "BAZ")]:
+        cur = conn.execute(f"select %{fmt_in}::text", [StrTestEnum[member]])
+        assert cur.fetchone()[0] == label
+        cur = conn.execute(f"select '{label}'::puretestenum", binary=fmt_out)
+        assert cur.fetchone()[0] is StrTestEnum[member]
+
+
+def test_remap_rename(conn):
+    enum = Enum("RenamedEnum", "FOO BAR QUX")
+    info = EnumInfo.fetch(conn, "puretestenum")
+    register_enum(info, conn, enum, mapping={enum.QUX: "BAZ"})
+
+    for member, label in [("FOO", "FOO"), ("BAR", "BAR"), ("QUX", "BAZ")]:
+        cur = conn.execute("select %s::text", [enum[member]])
+        assert cur.fetchone()[0] == label
+        cur = conn.execute(f"select '{label}'::puretestenum")
+        assert cur.fetchone()[0] is enum[member]
+
+
+def test_remap_more_python(conn):
+    enum = Enum("LargerEnum", "FOO BAR BAZ QUX QUUX QUUUX")
+    info = EnumInfo.fetch(conn, "puretestenum")
+    mapping = {enum[m]: "BAZ" for m in ["QUX", "QUUX", "QUUUX"]}
+    register_enum(info, conn, enum, mapping=mapping)
+
+    for member, label in [("FOO", "FOO"), ("BAZ", "BAZ"), ("QUUUX", "BAZ")]:
+        cur = conn.execute("select %s::text", [enum[member]])
+        assert cur.fetchone()[0] == label
+
+    for member, label in [("FOO", "FOO"), ("QUUUX", "BAZ")]:
+        cur = conn.execute(f"select '{label}'::puretestenum")
+        assert cur.fetchone()[0] is enum[member]
+
+
+def test_remap_more_postgres(conn):
+    enum = Enum("SmallerEnum", "FOO")
+    info = EnumInfo.fetch(conn, "puretestenum")
+    mapping = [(enum.FOO, "BAR"), (enum.FOO, "BAZ")]
+    register_enum(info, conn, enum, mapping=mapping)
+
+    cur = conn.execute("select %s::text", [enum.FOO])
+    assert cur.fetchone()[0] == "BAZ"
+
+    for label in PureTestEnum.__members__:
+        cur = conn.execute(f"select '{label}'::puretestenum")
+        assert cur.fetchone()[0] is enum.FOO
+
+
+def test_remap_by_value(conn):
+    enum = Enum(  # type: ignore
+        "ByValue",
+        {m.lower(): m for m in PureTestEnum.__members__},
+    )
+    info = EnumInfo.fetch(conn, "puretestenum")
+    register_enum(info, conn, enum, mapping={m: m.value for m in enum})
+
+    for label in PureTestEnum.__members__:
+        cur = conn.execute("select %s::text", [enum[label.lower()]])
+        assert cur.fetchone()[0] == label
+
+        cur = conn.execute(f"select '{label}'::puretestenum")
+        assert cur.fetchone()[0] is enum[label.lower()]


### PR DESCRIPTION
Recreated from original PR: https://github.com/psycopg/psycopg/pull/274

Postgres enum support (casting from/to Python `enum.Enum` types).

Based on #273